### PR TITLE
.validate() shouldn't accept datapackage as list

### DIFF
--- a/datapackage_validate/validation.py
+++ b/datapackage_validate/validation.py
@@ -51,7 +51,7 @@ def validate(datapackage, schema='base'):
             datapackage_obj = json.loads(datapackage)
         except ValueError as e:
             errors.append(exceptions.DataPackageValidateException(e))
-    elif not (isinstance(datapackage, dict) or isinstance(datapackage, list)):
+    elif not isinstance(datapackage, dict):
         msg = 'Data Package must be a dict or JSON string, but was a \'{0}\''
         dp_type = type(datapackage).__name__
         error = exceptions.DataPackageValidateException(msg.format(dp_type))


### PR DESCRIPTION
I'm not sure if it was intended or not, but the docs say that the datapackage can only be string or object, and the tests only test for those two cases, and the commit that introduced this change doesn't help much to understand the reasoning behind it (https://github.com/okfn/datapackage-validate-py/commit/0356a61b5867355b10ff2ae0d9427a515f4788de)

Given that, I suppose it was some test code that slipped into the repository. If not, please close this pull request.
