### PR TITLE
Rename "python object" to "python dict"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ import datapackage_validate
 valid, errors = datapackage_validate.validate(datapackage, schema)
 ```
 
-The `datapackage` can be a json string or python object.
+The `datapackage` can be a json string or python dict.
 
-The `schema` can be a json string, python object, or a schema id corresponding with a schema from the registry of [Data Package Profiles][]. `schema` is optional, and will default to the `base` schema id if not provided.
+The `schema` can be a json string, python dict, or a schema id corresponding with a schema from the registry of [Data Package Profiles][]. `schema` is optional, and will default to the `base` schema id if not provided.
 
 `validate()` returns a tuple (valid, errors):
 

--- a/datapackage_validate/validation.py
+++ b/datapackage_validate/validation.py
@@ -19,7 +19,7 @@ def _get_schema_url_from_registry(id, registry):
 
 
 def _fetch_schema_obj_from_url(url):
-    '''Fetch schema from url and return schema object'''
+    '''Fetch schema from url and return schema dict'''
     schema_response = requests.get(url)
     schema_response.raise_for_status()
     return json.loads(schema_response.text)
@@ -28,7 +28,7 @@ def _fetch_schema_obj_from_url(url):
 def validate(datapackage, schema='base'):
     '''Validate Data Package datapackage.json files against a jsonschema.
 
-    `datapackage` - a json string or python object
+    `datapackage` - a json string or python dict
     `schema` - a schema string id, json string, or python dict
 
     Return a tuple (valid, errors):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -98,7 +98,7 @@ class TestValidDatapackageJson(unittest.TestCase):
 
     @httpretty.activate
     def test_valid_json_obj(self):
-        '''Datapackage as valid Python object.'''
+        '''Datapackage as valid Python dict.'''
         httpretty.register_uri(httpretty.GET, REGISTRY_BACKEND_URL,
                                body=REGISTRY_BODY)
         httpretty.register_uri(httpretty.GET,
@@ -117,7 +117,7 @@ class TestValidDatapackageJson(unittest.TestCase):
 
     @httpretty.activate
     def test_invalid_json_obj(self):
-        '''Datapackage as invalid Python object.
+        '''Datapackage as invalid Python dict.
 
         Datapackage is well-formed JSON, but doesn't validate against schema.
         '''


### PR DESCRIPTION
Everything in Python is an object. To make the text clearer, use "dict"
instead.
